### PR TITLE
Use django-json-widget for a nicer json editing experience

### DIFF
--- a/crowdnewsroom/settings.py
+++ b/crowdnewsroom/settings.py
@@ -34,6 +34,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'corsheaders',
+    'django_json_widget',
     'forms.apps.FormsConfig',
     'django.contrib.admin',
     'django.contrib.auth',

--- a/forms/admin.py
+++ b/forms/admin.py
@@ -1,14 +1,10 @@
 from django.contrib import admin
 from django import forms
+from django.contrib.postgres import fields
 from django.utils.safestring import mark_safe
+from django_json_widget.widgets import JSONEditorWidget
 
 from .models import Investigation, Form, FormResponse
-
-
-class FRForm(forms.ModelForm):
-    class Meta:
-        model = FormResponse
-        exclude = ["json"]
 
 
 def rendered_response(obj: FormResponse):
@@ -43,6 +39,12 @@ class FormResponseAdmin(admin.ModelAdmin):
     exclude = ["reply"]
 
 
-admin.site.register(Form)
+class FormAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        fields.JSONField: {'widget': JSONEditorWidget}
+    }
+
+
+admin.site.register(Form, FormAdmin)
 admin.site.register(Investigation)
 admin.site.register(FormResponse, FormResponseAdmin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==2.0.1
 django-cors-headers==2.1.0
 psycopg2==2.7.3.2
 pytz==2017.3
+-e git+git@github.com:k-nut/django-json-widget.git@vendorize-jsoneditor#egg=django_json_widget


### PR DESCRIPTION
This provides an editor that can show you a tree structure
of your json fields as well as a pretty printed version of
the json which is much easier to edit then the default
textarea which just shows the unindented json in a textarea