### PR TITLE
disable django-restframework's html view

### DIFF
--- a/crowdnewsroom/settings.py
+++ b/crowdnewsroom/settings.py
@@ -141,6 +141,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
     )
 }
 


### PR DESCRIPTION
Django-Rest-Framework comes with a browsable API which renders information
about the API when users are making request with their web
browser directly instead of via AJAX.
As we do not expect anyone to be using our API right
now and do not include the required templates for these
views anyways (which actually cased some 500-erros) it makes sense to just turn it off for now.

We might to turn it on back later as it can be quite useful.