### PR TITLE
only send metadata in response api endpoint

### DIFF
--- a/forms/views.py
+++ b/forms/views.py
@@ -73,13 +73,14 @@ class AssigneeField(serializers.PrimaryKeyRelatedField):
         return User.objects.filter(id__in=[user.id for user in investigation_users])
 
 
-class CompleteFormResponseSerializer(ModelSerializer):
+class FormResponseMetaSerializer(ModelSerializer):
+    """ contains all information about the response that is not the submission itself"""
     tags = TagField(many=True, required=False)
     assignees = AssigneeField(many=True, required=False)
 
     class Meta:
         model = FormResponse
-        fields = "__all__"
+        exclude = ("json",)
 
 
 def get_investigation(instance):
@@ -95,7 +96,7 @@ class CanEditInvestigation(permissions.BasePermission):
 
 class FormResponseDetail(generics.RetrieveUpdateAPIView):
     lookup_url_kwarg = "response_id"
-    serializer_class = CompleteFormResponseSerializer
+    serializer_class = FormResponseMetaSerializer
     queryset = FormResponse
     permission_classes = [CanEditInvestigation]
 


### PR DESCRIPTION
we use this endpoint to update status, assignees, tags but never the submission itself. It therefore makes sense for us to not send the submission itself to avoid leaking it but also to make sure that the requests are fast (because they won't include the serialised files)