### PR TITLE
Make heading, breadcrumbs and tabs sticky in investigation management

### DIFF
--- a/forms/templates/forms/investigation_details.html
+++ b/forms/templates/forms/investigation_details.html
@@ -10,5 +10,19 @@
     <div id="investigation-details"></div>
 </div>
 
+<style>
+    .cnr--header{
+        position: sticky;
+        top: 0;
+        z-index: 9001;
+    }
+
+    .investigation-management__tabs {
+        position: sticky;
+        z-index: 9001;
+        top: 130px;
+    }
+</style>
+
 {% render_bundle "investigationManagement" %}
 {% endblock %}


### PR DESCRIPTION
This is implemented as a `style` tag because we do not want
to make the header/breadrumbs sticky on *all* pages but just
on *this* page.