### PR TITLE
get latest form when editing

### DIFF
--- a/forms/models.py
+++ b/forms/models.py
@@ -349,7 +349,7 @@ class FormResponse(models.Model):
                     row["type"] = "link"
                     row["value"] = reverse("response_file",
                                            kwargs={"investigation_slug": self.form_instance.form.investigation.slug,
-                                                   "form_slug": self.form_instance.form.slug,
+                                                   "form_slug": self.form_instance.get_latest_for_form.form.slug,
                                                    "response_id": self.id,
                                                    "file_field": name
                                                    })
@@ -363,7 +363,7 @@ class FormResponse(models.Model):
                     row["type"] = "link"
                     row["value"] = reverse("response_file_array",
                                            kwargs={"investigation_slug": self.form_instance.form.investigation.slug,
-                                                   "form_slug": self.form_instance.form.slug,
+                                                   "form_slug": self.form_instance.get_latest_for_form.form.slug,
                                                    "response_id": self.id,
                                                    "file_field": name,
                                                    "file_index": index

--- a/theme/src/scripts/forminstance-details.jsx
+++ b/theme/src/scripts/forminstance-details.jsx
@@ -152,6 +152,7 @@ class FormInstanceEditor extends Component {
     authorizedPOST(`/forms/forms/${this.state.form}/form_instances`, {
       body: JSON.stringify(this.state)
     }).then(() => {
+      window.location.reload();
       Notifications.success("Successfully updated form");
       this.props.toggleExpertMode();
     });


### PR DESCRIPTION
Addresses a bug where the json doesn't update in the browser after the form json has been edited. The issue here is that it needs to access the most recent instance of the form. Commit 
f3a6aa6 updates the django view so that the most recent instance is being given to the browser.

Commit 3a21e20 forces a page reload so that React will fetch the most recent form instance from the server. Not sure that this is really the best solution but it does handle the bug.