### PR TITLE
Adjust minio presigned url endpoint

### DIFF
--- a/forms/views.py
+++ b/forms/views.py
@@ -686,13 +686,12 @@ class PresignedUrl(generics.ListAPIView):
                 access_key=settings.MINIO_ACCESS_KEY,
                 secret_key=settings.MINIO_SECRET_KEY
             )
-
-            url = client.get_presigned_url(
-                "PUT",
+            
+            url = client.presigned_put_object(
                 "videos",
                 file_name,
-                expires=timedelta(days=1),
-                response_headers={"response-content-type": "application/json"},
+                expires=timedelta(days=1)
             )
+            
 
-        return Response({"url" : url})
+        return Response(url)


### PR DESCRIPTION
- use `presigned_put_object` method to allow direct upload via PUT
- simplify return, obj to string
- remove content type from response