### PR TITLE
Update models.py

### DIFF
--- a/forms/models.py
+++ b/forms/models.py
@@ -20,6 +20,7 @@ from django.utils.translation import ugettext_lazy as _
 from guardian.shortcuts import assign_perm, get_users_with_perms
 
 from .mixins import UniqueSlugMixin, validate_slug_stricter
+from minio import Minio
 
 Roles = namedtuple('Roles', ['ADMIN', 'OWNER', 'EDITOR', 'VIEWER'])
 INVESTIGATION_ROLES = Roles(ADMIN="A", OWNER="O", EDITOR="E", VIEWER="V")
@@ -425,8 +426,23 @@ class FormResponse(models.Model):
                             if prop['next_slide'] == row["value"]:
                                 row["value"] = prop['name']
                     else:
-                        row["type"] = "text"
-                        row["value"] = form_data.get(name, "")
+                        if props.get("slug") is not None and 'video' in props.get("slug"):
+                            mc = Minio(
+                                settings.MINIO_ASSETS_URL,
+                                access_key=settings.MINIO_ACCESS_KEY,
+                                secret_key=settings.MINIO_SECRET_KEY
+                            )
+                            url = mc.get_presigned_url(
+                                "GET",
+                                "videos",
+                                form_data.get(name, ""),
+                                expires=timedelta(days=1),
+                            )
+                            row["type"] = "link"
+                            row["value"] = url
+                        else:
+                            row["type"] = "text"
+                            row["value"] = form_data.get(name, "")
                 else:
                     row["type"] = "text"
                     row["value"] = form_data.get(name, "")


### PR DESCRIPTION
Proposal of minio pre signed url handling in admin ui.

- use a slug  which contains the word `video`
- compare slug in models and generate pre_signed url on request
- output as file field with download link in form responses

### why?
Currently, its a problem to use format options in json schema form due validation purposes. A simple string text field is working fine with vadlitaionb, only the filename as string is in form submit.

This and #21  ist working with the current frontend integrations of https://github.com/correctiv/crowdnewsroom-frontend/tree/videoupload